### PR TITLE
feat: pass BlockEnv into block_stm & vm

### DIFF
--- a/src/block_stm.rs
+++ b/src/block_stm.rs
@@ -4,7 +4,7 @@ use std::{
     thread,
 };
 
-use revm::primitives::{ResultAndState, TxEnv};
+use revm::primitives::{BlockEnv, ResultAndState, TxEnv};
 
 use crate::{
     mv_memory::MvMemory,
@@ -21,11 +21,15 @@ pub struct BlockSTM;
 impl BlockSTM {
     /// Run a list of REVM transactions through Block-STM.
     /// TODO: Better concurrency control
-    pub fn run(txs: Arc<Vec<TxEnv>>, concurrency_level: NonZeroUsize) -> Vec<ResultAndState> {
+    pub fn run(
+        block_env: BlockEnv,
+        txs: Arc<Vec<TxEnv>>,
+        concurrency_level: NonZeroUsize,
+    ) -> Vec<ResultAndState> {
         let block_size = txs.len();
         let scheduler = Scheduler::new(block_size);
         let mv_memory = Arc::new(MvMemory::new(block_size));
-        let vm = Vm::new(txs.clone(), mv_memory.clone());
+        let vm = Vm::new(block_env, txs.clone(), mv_memory.clone());
         let execution_results = Mutex::new(vec![None; txs.len()]);
         // TODO: Better thread handling
         thread::scope(|scope| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,8 @@
 
 use block_stm_revm::{BlockSTM, Storage};
 use revm::primitives::alloy_primitives::U160;
-use revm::primitives::Address;
 use revm::primitives::{env::TxEnv, ResultAndState};
+use revm::primitives::{Address, BlockEnv};
 use revm::Evm;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -47,6 +47,7 @@ fn main() {
 
     let start_time = SystemTime::now();
     let result_block_stm = BlockSTM::run(
+        BlockEnv::default(),
         txs,
         thread::available_parallelism().unwrap_or(NonZeroUsize::MIN),
     );


### PR DESCRIPTION
Addresses #15.

Also unblocks #18 by providing `Vm` the beneficiary account (`block_env.coinbase`), for it to atomically update beneficiary balance via a custom `PostExecutionHandler::reward_beneficiary`, and to intercept explicit reads (& writes) to wait for all updates of the lower transactions.