### PR TITLE
Pass `SpecId` into `BlockSTM` & `VM`

### DIFF
--- a/src/block_stm.rs
+++ b/src/block_stm.rs
@@ -4,7 +4,7 @@ use std::{
     thread,
 };
 
-use revm::primitives::{BlockEnv, ResultAndState, TxEnv};
+use revm::primitives::{BlockEnv, ResultAndState, SpecId, TxEnv};
 
 use crate::{
     mv_memory::{MvMemory, ReadMemoryResult},
@@ -23,6 +23,7 @@ impl BlockSTM {
     /// TODO: Better concurrency control
     pub fn run(
         storage: Storage,
+        spec_id: SpecId,
         block_env: BlockEnv,
         txs: Vec<TxEnv>,
         concurrency_level: NonZeroUsize,
@@ -32,7 +33,7 @@ impl BlockSTM {
         let mv_memory = Arc::new(MvMemory::new(block_size));
         // TODO: Better error handling
         let mut beneficiary_account_info = storage.basic(block_env.coinbase).unwrap();
-        let vm = Vm::new(storage, block_env.clone(), txs, mv_memory.clone());
+        let vm = Vm::new(storage, spec_id, block_env.clone(), txs, mv_memory.clone());
         // TODO: Should we move this to `Vm`?
         let execution_results = (0..block_size).map(|_| Mutex::new(None)).collect();
         // TODO: Better thread handling

--- a/tests/beneficiary.rs
+++ b/tests/beneficiary.rs
@@ -4,16 +4,20 @@
 // TODO: Add more test scenarios around the beneficiary account's activities in the block.
 
 use rand::random;
-use revm::primitives::{alloy_primitives::U160, env::TxEnv, Address, BlockEnv, TransactTo, U256};
+use revm::primitives::{
+    alloy_primitives::U160, env::TxEnv, Address, BlockEnv, SpecId, TransactTo, U256,
+};
 
 mod common;
 
 #[test]
 fn beneficiary() {
-    let block_size = 100_000; // number of transactions
+    let spec_id = SpecId::LATEST;
     let block_env = BlockEnv::default();
+    let block_size = 100_000; // number of transactions
 
     common::test_txs(
+        spec_id,
         block_env,
         // Mock `block_size` transactions sending some tokens to itself.
         // Skipping `Address::ZERO` as the beneficiary account.

--- a/tests/raw_transfers.rs
+++ b/tests/raw_transfers.rs
@@ -2,16 +2,20 @@
 // Currently, we only have a no-state-conflict test of user account sending to themselves.
 // TODO: Add more tests of accounts cross-transferring to create state depdendencies.
 
-use revm::primitives::{alloy_primitives::U160, env::TxEnv, Address, BlockEnv, TransactTo, U256};
+use revm::primitives::{
+    alloy_primitives::U160, env::TxEnv, Address, BlockEnv, SpecId, TransactTo, U256,
+};
 
 mod common;
 
 #[test]
 fn raw_transfers() {
-    let block_size = 100_000; // number of transactions
+    let spec_id = SpecId::LATEST;
     let block_env = BlockEnv::default();
+    let block_size = 100_000; // number of transactions
 
     common::test_txs(
+        spec_id,
         block_env,
         // Mock `block_size` transactions sending some tokens to itself.
         // Skipping `Address::ZERO` as the beneficiary account.


### PR DESCRIPTION
Addresses #16 and enables #5 as we test & sync throughout the eras.